### PR TITLE
clean up readme listener example

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,14 +194,11 @@ export default connect(
     [[]],
     ([state]) => ({}),
     {
-        listeners: [
-            {
-                event: 'EVENT_TYPE',
-                listener: () => {
-                    this.reactToEvent();
-                }
-            }
-        ]
+        listeners: {
+            'EVENT_TYPE': () => {
+                 this.reactToEvent();
+             }
+         }
     }
 )(MyComponent);
 ```


### PR DESCRIPTION
Noticed this example for listeners with an array of listeners doesn't seem to currently supported by the [code](https://github.com/chandlerprall/react-insula/blob/master/src/Connect.js#L73).

Was this the original design? an additional support down the road?